### PR TITLE
Obohaceni parseru o filtr klicovych slov.

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -19,7 +19,7 @@
 #include "token.h"
 #include "error.h"
 #include "dstring.h"
-
+#include "conversion.h"
 
 int repeatLastChar = 0;
 TToken* readToken;
@@ -148,6 +148,7 @@ TToken* GetNextToken() {
   //readToken->string = StringMinClone(readString);
   //printf("%s\n",readString->string);
   StringDestroy(readString);
+  Convert(readToken);
   return readToken;
 }
 


### PR DESCRIPTION
Pred vracenim tokenu je token poslan do filtu.
Pokud je token TK_ID a je to klicove slovo, tak bude zmenen typ tokenu.
Pokud je cislo TK_NUM_INTEGER nebo TK_NUM_DOUBLE tak
je string preveden na hodnotu a ta je ulozena do tokenu.